### PR TITLE
Allow invocation as main module

### DIFF
--- a/mtls/__main__.py
+++ b/mtls/__main__.py
@@ -1,0 +1,2 @@
+from .cli import cli
+cli()


### PR DESCRIPTION
This allows us to invoke with `python -m mtls`

Thanks to https://stackoverflow.com/questions/43393764/python-3-6-project-structure-leads-to-runtimewarning/45070583#45070583