### PR TITLE
Update click library usage

### DIFF
--- a/mtls/cli.py
+++ b/mtls/cli.py
@@ -133,7 +133,7 @@ def get_servers(ctx, args, incomplete):
     "-s",
     type=str,
     help="Server to run command against.",
-    autocompletion=get_servers,
+    shell_complete=get_servers,
 )
 @click.option(
     "--config",


### PR DESCRIPTION
`autocompletion` was deprecated in 8.0.0, removed in click 8.1.0

https://click.palletsprojects.com/en/8.1.x/changes/#version-8-1-0

![image](https://user-images.githubusercontent.com/35791147/162350805-e0fa061b-0be2-45d7-90e1-49b6bdbb23df.png)
